### PR TITLE
communication: Add guidance on times and timezones

### DIFF
--- a/company/communication.md
+++ b/company/communication.md
@@ -1,0 +1,16 @@
+As a distributed company we should be mindful of how we communicate.
+
+## Timezones
+
+### Use UTC for times
+
+Unless explicitly stated otherwise, communicate times in UTC. This allows each
+team member to remember just their offset to UTC and makes communication around
+timezones less error-prone (e.g. misremembering your own offset to a collegues
+timezone) and more efficient. **Exception**: When communicating to meet in 
+phisical locations, the timezone of that location will be assumed as default.
+
+### Time of day
+
+A 24 hour clock is assumed in time notations like `10:00`, when referencing a
+time in the afternoon either use e.g. `15:00` or explicitly `3 PM`.

--- a/company/index.md
+++ b/company/index.md
@@ -3,3 +3,4 @@
  - [About](../company/about.md)
  - [Values](../company/values.md)
  - [Strategy](../company/strategy.md)
+ - [Communication](./communication.md)


### PR DESCRIPTION
Most mistakes I've made in the past around communications and scheduling
are miscommunications around times and their notation, or timezones
with offsets.

For timezones, most servers are set to UTC for convenience. While this
is not the reason to recommend it, it was the inspiration to suggest it
for the company too. When one goes into summer time, their offset
changes, and only theirs. Putting the responsibility on each and
everyone to remember the offset tot UTC is more convenient for the
entire company.

Around times themself: a 24 hour clock unambiguously communicates when a
meeting is to take place. Using AM/PM is fine though, but has to be
explicitly communicated.