### PR TITLE
Fix links to communications page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ and strongly encouraged.
  - [About](./company/about.md)
  - [Values](./company/values.md)
  - [Strategy](./company/strategy.md)
+ - [Communication](./company/communication.md)
 
 ### Colophon
 

--- a/company/index.md
+++ b/company/index.md
@@ -3,4 +3,4 @@
  - [About](../company/about.md)
  - [Values](../company/values.md)
  - [Strategy](../company/strategy.md)
- - [Communication](./communication.md)
+ - [Communication](../company/communication.md)


### PR DESCRIPTION
Due to the way the handbook content is published on the website, links between pages have to be handled slightly strangely to ensure the generated links work as expected.