### PR TITLE
communication: Document how to run meetings

### DIFF
--- a/company/communication.md
+++ b/company/communication.md
@@ -14,3 +14,28 @@ phisical locations, the timezone of that location will be assumed as default.
 
 A 24 hour clock is assumed in time notations like `10:00`, when referencing a
 time in the afternoon either use e.g. `15:00` or explicitly `3 PM`.
+
+## Meetings
+
+### General guidance
+
+Each meeting should have an agenda. This allows potential participants to prepare
+and decide whether attendance is required. Any partipant can add items to the
+agenda, please prefix your item with your name or initials to communcate who's
+going to talk and lead the discussion. Adding new items to the agenda while the
+meeting is started is good practise and can be leveraged to keep the currently
+discussed item focussed and on-rails.
+
+### During the meeting
+
+Meetings start on time by the person with the first item on the agenda, verbalize
+and discuss the item. Once done, hand over to the owner of the next agenda item.
+
+During the meeting notes should be taken in an inline fashion. Non-participants
+can then read the agenda after the meeting and are up-to-date without having to
+scroll to a notes section.
+
+### Coffee calls
+
+Coffee calls are social of nature and thus are the exception to the rule that
+each meeting should have an agenda.


### PR DESCRIPTION
This change is mostly a carbon copy of how most meetings were run at
GitLab. What I think is great about most of these points:
- It allows everyone to have a voice
- Highly focussed meetings on what's the agenda
- Great documentation for non-participants after the meeting

All things considered it might be bit of work to get used to, but worth
the initial pain.