### PR TITLE
development: Introduce Launch Lunch

### DIFF
--- a/development/index.md
+++ b/development/index.md
@@ -4,7 +4,9 @@
 
 - [Packaging](../development/packaging.md)
 
-### Release cadence
+## Releases
+
+### Cadence
 
 FlowForge is released every four weeks, on a Thursday. There's 13 releases each
 year. The initial release is scheduled for the 20th of January. This implies:
@@ -13,3 +15,8 @@ v0.2 is scheduled for 2022/02/17
 
 v0.3 is scheduled for 2022/03/17
 
+### Launch Lunch
+
+To celebrate the launch of a new version of FlowForge, we organize a lunch on the
+release day. Each team member is encouraged to order a lunch (Expensable up to 20$
+per launch) and join a social lunch zoom call.


### PR DESCRIPTION
To encourage a celebrative moment and social calls organize a lunch
each 4 weeks to meet and eat.