### PR TITLE
development: Document when to retro/kick-off a release

### DIFF
--- a/development/index.md
+++ b/development/index.md
@@ -15,6 +15,13 @@ v0.2 is scheduled for 2022/02/17
 
 v0.3 is scheduled for 2022/03/17
 
+### Retrospective
+
+The day after each FlowForge release, always a Friday, a meeting is scheduled
+by the CTO. This meeting includes 3 parts: a retrospective on the last release,
+complete scheduling for the next release, and kick off development for the next
+release.
+
 ### Launch Lunch
 
 To celebrate the launch of a new version of FlowForge, we organize a lunch on the


### PR DESCRIPTION
This was discussed in a meeting today, capturing it in the handbook now
to formalize it.