### PR TITLE
peopleops: Document vacation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and strongly encouraged.
  - [Strategy](./company/strategy.md)
  - [Communication](./company/communication.md)
  - [Development](./development)
+ - [PeopleOps](./peopleops)
 
 ### Colophon
 

--- a/peopleops/index.md
+++ b/peopleops/index.md
@@ -1,0 +1,17 @@
+## Vacation Policy
+
+FlowForge has a unlimited time off policy. Taking vacation is encouraged for all
+team members. To prevent an undefined number of vacation days to start a race to
+the bottom, we recommend each team member to take a minimum of 25 days a year,
+and at least 5 days a quarter.
+
+### Logging time off
+
+When taking more than 3 days off consecutively, tell (don't ask) your manager. 
+This ensure scheduling of work and operations continue to run smoothly without
+you. When taking over 2 weeks of consecutively seek approval from your manager.
+
+Before you can take time off you should _always_:
+* Log your time off in BambooHR
+* Add an 'Out of office' appointment in your personal Google Calendar, and decline
+   all meetings automatically.


### PR DESCRIPTION
Unlimited PTO can lead to a race to the bottom, hope this policy
prevents such a race. Further there's legal requirements to document
when someone has taken vacation to prove they've taken it. This too is
now documented.

Closes #10 