### PR TITLE
Add requirement to setup project-automation on new repositories

### DIFF
--- a/development/packaging.md
+++ b/development/packaging.md
@@ -1,6 +1,6 @@
 Flow Forge Packaging Guidelines
 
-## Github projects 
+## Github projects
 
 ### Naming
 
@@ -17,7 +17,7 @@ All Git Repositories must contain the following files:
 
 ### Notifications
 
-Repositories should be added to the appropriate Slack channel. For core code reposities,
+Repositories should be added to the appropriate Slack channel. For core code repositories,
 this would be in the `#gh-flowforge` channel.
 
 To create a subscription, go to that channel and type the message:
@@ -28,13 +28,22 @@ To create a subscription, go to that channel and type the message:
 
 This will subscribe to any notifications covering: `issues`, `pulls`, `commits`, `releases`, `deployments` and `comments`
 
+### Workflows
+
+All code repositories must have the Project Automation workflow added. This is done
+by adding [`.github/workflows/project-automation.yml`](https://github.com/flowforge/flowforge/blob/main/.github/workflows/project-automation.yml). This workflow will ensure any
+issues or PRs opened/closed against the repo are automatically tracked on the Development
+[Project board](https://github.com/orgs/flowforge/projects/1)
+
+**Note**: this workflow can only be added to *public* repositories in the organisation.
+
 ## NPM packages
 
 ### Naming
 
 - All packages should be scoped to `@flowforge`
 
-Node-RED plugins should start with `nr-` e.g. 
+Node-RED plugins should start with `nr-` e.g.
  - @flowforge/nr-storage
  - @flowforge/nr-auth
 
@@ -75,7 +84,7 @@ The `package.json` must contain the following keys
         "name": "FlowFlow Inc."
     },
     ```
- 
+
 ### Package Version Numbering
 
 Package numbers should follow the Semantic Versioning Scheme as laid out on [semver.org](https://semver.org/).


### PR DESCRIPTION
Until GitHub add the missing feature of automatically adding issues/prs to project boards, we have to add a GH Action to each repository to do it for us.

This PR adds guidance on how to do that as part of our repository setup requirements.