### PR TITLE
Proposal: Expand Friday meeting to replace Monday meeting

### DIFF
--- a/development/index.md
+++ b/development/index.md
@@ -40,6 +40,15 @@ A planning meeting is held at the start of the release. In this meeting the team
 discuss the current backlog of stories, tasks and bugs to propose items to be added
 to the release. All items assigned to a milestone should have an assigned owner.
 
+### Weekly Update
+
+We meet as a team on Friday morning to update each other on progress that week and
+to share our goals for the following week. This gives everyone a chance
+co-ordinate their work for the following week whilst things are fresh in their heads.
+
+This also means that, come the start of the following week, everyone should already
+have in mind what needs doing.
+
 ### Retrospective
 
 The day after each FlowForge release, always a Friday, a meeting is scheduled


### PR DESCRIPTION
To accommodate colleagues who don't work on Mondays we need to shift our regular Monday call so they don't miss out.

One option would be to move it to Tuesday. But the concern is we lose a day's momentum at the start of the week.

This PR proposes we expand the current Friday meeting to be more than the end-of-week checkpoint - use it to also share each of our plans for the following week.

That means:
 - no-one is excluded
 - we set out our plans for the following week when the work is still fresh in our minds, rather than trying remember where we got to on Monday morning.


The current meeting is 30mins at 11:30(GMT). If this proposal is agreed, the meeting will become 1hr at 10:00(GMT).