### PR TITLE
values: Update the list with "Be Trusting"

### DIFF
--- a/company/values.md
+++ b/company/values.md
@@ -1,24 +1,63 @@
+## Be Effective
+
+> [effective][effective-oxford] - producing the result that is wanted or intended; producing a successful result
+
+[effective-oxford]: https://www.oxfordlearnersdictionaries.com/definition/english/effective
+
+Being effective is split up in two parts; producing results and communication
+about what our goals are.
+
+### Results
+
+We value results over measuring hours spent working. We do not dictate how
+someone should schedule their day - we trust individuals to do what is right.
+Everyone should feel empowered to do the work needed to achieve our goals.
+
+There may be times when more is needed to meet a goal, deadline or customer
+situation. We take the responsibility to ensure they are the exceptions rather
+than the rule.
+
+#### Bias for action
+
+We value getting things done and continually moving forward. It is better to 
+iterate rapidly rather than get stuck over-thinking a problem. We move with an
+urgency and a focus to achieve our best.
+
+When you disagree with a solution to a problem, provide a concrete alternate
+solution to allow momentum to be maintained or even gained.
+
+#### Be trusting
+
+To move with high velocity, trust needs to be given before one has had the
+opportunity to earn it. People can only grow when they're able to take up
+challenging tasks and project, and are then allowed to go their own route. When
+challenged, ask for feedback and support, not for permission or approval.
+
+### Communication
+
 ### Be a community
 
-As an open core company our community spans our employees, the open source contributors and our users. We strive to build a healthy, positive community through our values and actions.
-We celebrate the diversity of others, we listen to each other, we support each other.
+As an open core company our community spans our employees, the open source
+contributors and our users. We strive to build a healthy, positive community
+through our values and actions. We celebrate the diversity of others, we listen
+to each other, we support each other.
 
-We are inclusive of all and are mindful of how our words and actions can impact others. We welcome discussion and debate, but take care to ensure it is not at the expense or exclusion of others. We value empathy, courtesy and respect for each other.
-
-### Focus on results
-
-We value results over measuring hours spent working. We do not dictate how someone should schedule their day - we trust individuals to do what is right. Everyone should feel empowered to do the work needed to achieve our goals.
-
-There may be times when more is needed to meet a goal, deadline or customer situation. We take the responsibility to ensure they are the exceptions rather than the rule.
-
-### Bias for action
-
-We value getting things done and continually moving forward. It is better to iterate rapidly rather than get stuck over-thinking a problem. We move with an urgency and a focus to achieve our best.
+We are inclusive of all and are mindful of how our words and actions can impact
+others. We welcome discussion and debate, but take care to ensure it is not at
+the expense or exclusion of others. We value empathy, courtesy and respect for
+each other.
 
 ### Use candor
 
-We use truth as a superpower, even when inconvenient to ourselves. We use it with care and consideration of others. We won’t get everything right all of the time. The only way we can improve is by being honest with ourselves and each other. It can be difficult to achieve and it can feel awkward. When done right, with respect and a shared understanding, it can lead to a better outcome for everyone.
+We use truth as a superpower, even when inconvenient to ourselves. We use it
+with care and consideration of others. We won’t get everything right all of the
+time. The only way we can improve is by being honest with ourselves and each
+other. It can be difficult to achieve and it can feel awkward. When done right, 
+with respect and a shared understanding, it can lead to a better outcome for
+everyone.
 
 ### Be optimistic
 
-We will treat all situations with an optimism that a positive result is possible. We don’t let that get in the way of planning for all outcomes and making the hard choices when they are needed.
+We will treat all situations with an optimism that a positive result is
+possible. We don’t let that get in the way of planning for all outcomes and
+making the hard choices when they are needed.


### PR DESCRIPTION
This commit does a few things:

1. Fix the formatting of the markdown to stay within 80 char limits.
   This is a personal preference, so this change limits it to this page
   just so I was able to parse what we had already.
2. Create a header: "Be Effective", all our values combined already
   wanted this from us at this company, just implimitly. However, being
   explicit we could subdivide the values in two classes: Results and
   Communication (having a shared set of goals).
3. Add "Be Trusting" to the list of values. The why is described in the
   changeset itself.