### PR TITLE
peopleops: Don't record sick leave

### DIFF
--- a/peopleops/index.md
+++ b/peopleops/index.md
@@ -18,6 +18,12 @@ Before you can take time off you should _always_:
 * Add an 'Out of office' appointment in your personal Google Calendar, and decline
    all meetings automatically.
 
+#### Sick leave
+
+Sick leave, or having limited availibility is not recorded currently. Keep your
+manager updated on your health, and let them know what FlowForge can do for you
+to aid in your recovery.
+
 ## Expenses
 
 The company will cover any reasonable work-related expense, including ensuring you


### PR DESCRIPTION
Currently there's no way to record sick leave, so this change just makes
this the policy. There seems to be no requirement in the UK or NL to
record this if it's short term. As such, this policy should *hopefully*
last us very long.