### PR TITLE
company: Hire for value fit over culture fit

### DIFF
--- a/company/team.md
+++ b/company/team.md
@@ -1,9 +1,15 @@
-## Interviews
+## Hiring
+
+### Interviews
 
 When a candidate applied they'll have at least two interviews with two different
 interviewers before an offer is extended to them. One interview will investigate
 the [fit on values](../company/values.md). The second will be a competency based
 interview.
+
+When interviewing to hire new team members, optimize for value-fit over
+culture-fit. Hiring for value-fit allows others to add to culture and thus fosters
+diversity and inclusivity.
 
 ## Onboarding
 


### PR DESCRIPTION
Culture is taught to new hires, and created by a whole team. It's not
static, and thus it's hard to hire for. Values are much more stable and
thus easier to hire for. Trust that if the values are shared, the
culture will follow, and thus hire for value fit.