### PR TITLE
Update release instructions

### DIFF
--- a/development/release.md
+++ b/development/release.md
@@ -14,12 +14,12 @@ The follow process should be followed for a FlowForge release.
 
  - Use the `checkout-release` script (from the admin project) to check out clean clones of the packages required to do a release 
  (e.g. `./checkout-release 0.4.0` will create a directory called `release-0.4.0` containing all the required projects)
- - If required, ensure that the correct `user.name` and `user.email` git configuration settings are in place for each repository
+ - If required, ensure that the correct `user.name` and `user.email` git configuration settings are in place for each repository (only a problem if not using a global configuration)
  - From within the `release-0.4.0` directory run the `prepare-release 0.4.0` script (from the admin project). This will update all the required
  `package.json` and `CHANGELOG.md` file updates then raise PRs to update the projects.
  - Have update PR reviewed by somebody other than the Release Manager
  - All package numbering PRs to be merged, and releases to be tagged, in the order defined in the admin project release issue. Between each release
- ensure that the previous package has been sucessfully published to npmjs.org.
+ ensure that the previous package has been sucessfully published to npmjs.org (bot will post to #gh-flowforge Slack channel or look on npmjs.org page for each package).
  - Once all the node module components have been built and published to npm the `installer`, `helm` and `docker-compose` components can be updated and tagged.
 
 ## Next Steps

--- a/development/release.md
+++ b/development/release.md
@@ -14,11 +14,13 @@ The follow process should be followed for a FlowForge release.
 
  - Use the `checkout-release` script (from the admin project) to check out clean clones of the packages required to do a release 
  (e.g. `./checkout-release 0.4.0` will create a directory called `release-0.4.0` containing all the required projects)
+ - If required, ensure that the correct `user.name` and `user.email` git configuration settings are in place for each repository
  - From within the `release-0.4.0` directory run the `prepare-release 0.4.0` script (from the admin project). This will update all the required
- `package.json` files and raise PRs to update the projects.
+ `package.json` and `CHANGELOG.md` file updates then raise PRs to update the projects.
  - Have update PR reviewed by somebody other than the Release Manager
- - All package numbering PRs to be merged, and releases to be tagged, in the order defined in the auto-generated release issue in the admin project.
- - Once all the components have been built and published to npm the `installer`, `helm` and `docker-compose` components can be updated and tagged.
+ - All package numbering PRs to be merged, and releases to be tagged, in the order defined in the admin project release issue. Between each release
+ ensure that the previous package has been sucessfully published to npmjs.org.
+ - Once all the node module components have been built and published to npm the `installer`, `helm` and `docker-compose` components can be updated and tagged.
 
 ## Next Steps
 


### PR DESCRIPTION
Added details about waiting between npm publishes
Also make sure git user.name and user.email are set before running `prepare-release` script