### PR TITLE
Add instructions for bundling nodes into stacks

### DIFF
--- a/development/packaging.md
+++ b/development/packaging.md
@@ -120,3 +120,20 @@ Major and minor releases will follow the schedule laid out in the [Cadence](inde
 A Fix release can be made at any time, depending on the best judgement of the engineer making the fix but requires a review by another team member.
 
 The process for making a release is documented [here](./release.md).
+
+
+### Adding NPM packages to Stacks
+
+As we build more FlowForge specific nodes we will need to add these to the Stacks
+
+#### Localfs
+
+Currently bundled packages for the localfs driver need to be added to the [flowforge-nr-launcher](https://github.com/flowforge/flowforge-nr-launcher) `package.json`. And path to the node needs to be added to the `nodesDir` array in the `lib/lancher.js` file (arround line 70). This will be updated in the next release to be controlled by the [flowforge-driver-localfs](https://github.com/flowforge/flowforge-driver-localfs) project
+
+#### Docker
+
+Any nodes or theams should be added to the `package.json` in `node-red-container/` directory of the [docker-compose](https://github.com/flowforge/docker-compose) project
+
+#### K8s
+
+Any nodes or theams should be added to the `package.json` in `node-red-container/` directory of the [helm](https://github.com/flowforge/helm) project

--- a/development/packaging.md
+++ b/development/packaging.md
@@ -128,12 +128,12 @@ As we build more FlowForge specific nodes we will need to add these to the Stack
 
 #### Localfs
 
-Currently bundled packages for the localfs driver need to be added to the [flowforge-nr-launcher](https://github.com/flowforge/flowforge-nr-launcher) `package.json`. And path to the node needs to be added to the `nodesDir` array in the `lib/lancher.js` file (arround line 70). This will be updated in the next release to be controlled by the [flowforge-driver-localfs](https://github.com/flowforge/flowforge-driver-localfs) project
+Currently bundled packages for the localfs driver need to be added to the [flowforge-nr-launcher](https://github.com/flowforge/flowforge-nr-launcher) `package.json`  and the path to the node needs to be added to the `nodesDir` array in the `lib/lancher.js` file (around line 70). This will be updated in the next release to be controlled by the [flowforge-driver-localfs](https://github.com/flowforge/flowforge-driver-localfs) project
 
 #### Docker
 
-Any nodes or theams should be added to the `package.json` in `node-red-container/` directory of the [docker-compose](https://github.com/flowforge/docker-compose) project
+Any nodes or themes should be added to the `package.json` in `node-red-container/` directory of the [docker-compose](https://github.com/flowforge/docker-compose) project
 
 #### K8s
 
-Any nodes or theams should be added to the `package.json` in `node-red-container/` directory of the [helm](https://github.com/flowforge/helm) project
+Any nodes or themes should be added to the `package.json` in `node-red-container/` directory of the [helm](https://github.com/flowforge/helm) project


### PR DESCRIPTION
Ticking off my todo item from the 0.8 retrospective

This adds details of where extra nodes should be added to the default stacks.