### PR TITLE
peopleops: Disclose our data source for comp data

### DIFF
--- a/peopleops/compensation.md
+++ b/peopleops/compensation.md
@@ -2,7 +2,8 @@
 
 Total compensation consists of 3 elements, salary, equity, and benefits.
 FlowForge aims to provide a total compensation package on par with similar
-companies in terms of: stage of the company, market, role, and level of the role.
+companies in terms of: stage of the company, market, role, and level in the role.
+The data to validate our compensation is obtained through OptionImpact/Pave.com.
 
 ## Salary
 


### PR DESCRIPTION
Recently I've been asked what data source we use to check if we're competitive. As there's no reason not to be open about our data source I've included it in the handbook now.