### PR TITLE
peopleops: Reintroduce the Launch Lunch

### DIFF
--- a/development/release.md
+++ b/development/release.md
@@ -107,3 +107,9 @@ The unmanaged repositories listed above have a simpler release process.
 1. Open a new PR to merge the package.json and CHANGELOG.md changes - get it merged
 1. Tag new release in GitHub with the appropriate version number eg `v0.1.1`. Copy the CHANGELOG update into the description.
 1. Once the release is created, the GitHub Action will take care of publishing to NPM. Check the action to ensure it completes.
+
+## Launch Lunch
+
+To celebrate the launch of a new version of FlowForge, we organize a lunch on
+the release day. Each team member is encouraged to order a lunch (Expensable up
+to 25$ per launch) and join a social lunch zoom call.

--- a/peopleops/compensation.md
+++ b/peopleops/compensation.md
@@ -51,6 +51,7 @@ offer location dependant benefits to ensure standards are met.
 ### For everyone
 
 - [Unlimited PTO](./index.md#vacation-policy)
+- [Launch Lunch](../development/release.md#launch-lunch)
 
 #### 1Password Family
 


### PR DESCRIPTION
In practise the lunch was organised already, but was never reintroduced in the handbook. This change commits it again.