### PR TITLE
Clean the primary Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,19 @@ and strongly encouraged.
 
  - [Values](./company)
  - [Strategy](./company/strategy.md)
- - [Communication](./company/communication.md)
- - [Design](./design)
- - [Development](./development)
- - [PeopleOps](./peopleops)
- - [Security](./company/security.md)
  - [Operations](./operations)
  - [Product](./product)
+### Development & Design Practices
 
-### Colophon
+ - [Design](./design)
+ - [Development](./development)
+### Internal Operations
+
+ - [Communication](./company/communication.md)
+ - [PeopleOps](./peopleops)
+ - [Security](./company/security.md)
+ 
+### About the Handbook
 
 The FlowForge handbook is inspired by the [GitLab handbook](https://about.gitlab.com/handbook/about/).
 As an all-remote company, we share [their rationale](https://about.gitlab.com/handbook/about/#advantages) for having a handbook.


### PR DESCRIPTION
Re-organising the main table of contents to make it easier to navigate around the different sections of the Handbook. Also renamed "Colophon" as I felt that was unclear.

**Before:**

<img width="698" alt="Screenshot 2022-10-12 at 09 39 07" src="https://user-images.githubusercontent.com/99246719/195294130-7509eafb-8f02-473c-ba21-d7d24d90431d.png">

**After:**
<img width="714" alt="Screenshot 2022-10-12 at 09 39 29" src="https://user-images.githubusercontent.com/99246719/195294227-ece171bf-be03-4215-9f4e-e578fdc37c8b.png">
