### PR TITLE
Add list of standard labels for repositories

### DIFF
--- a/development/packaging.md
+++ b/development/packaging.md
@@ -80,8 +80,8 @@ ensures we have a consistent approach to planning and tracking of work.
 
  - Type: `epic`, `story`, `task`, `bug`
  - Sizing: `1`, `2`, `3`, `5`, `8`, `13`
- - Area: `docs`, `db`, `migration`, `frontend`, `api`, `device`
- - Priority: `p-1`, `p-2`, `p-3`
+ - Area: `area:docs`, `area:db`, `area:migration`, `area:frontend`, `area:api`, `area:device`
+ - Priority: `priority:high`, `priority:medium`, `priority:low`
  - Status: `blocked`
  - Product Scope: `scope:devices`, `scope:enterprise`, `scope:node-red`, `scope:collaboration`
  - Other: `good first issue`, `upstream`

--- a/development/packaging.md
+++ b/development/packaging.md
@@ -84,7 +84,13 @@ ensures we have a consistent approach to planning and tracking of work.
  - Priority: `priority:high`, `priority:medium`, `priority:low`
  - Status: `blocked`
  - Product Scope: `scope:devices`, `scope:enterprise`, `scope:node-red`, `scope:collaboration`
- - Other: `good first issue`, `upstream`
+ - Other: `good first issue`, `upstream`, `needs-triage`
+
+The labels are synchronized across the repositories via a GitHub Action in the [`.github`](https://github.com/flowforge/.github)
+repository.
+ 
+New repositories must be added to the list in [`flowforge-repositories.yml`](https://github.com/flowforge/.github/blob/main/flowforge-repositories.yml),
+and then the [Synchronize Labels](https://github.com/flowforge/.github/actions/workflows/sync-labels.yml) action manually run.
  
 ## NPM packages
 

--- a/development/packaging.md
+++ b/development/packaging.md
@@ -73,6 +73,19 @@ they cannot access the organisation-wide secret we have in place.
 2. Add it as a Repository Secret to the Private Repo (https://github.com/flowforge/<repo-name>/settings/secrets/actions)
    with the name `PROJECT_ACCESS_TOKEN`
 
+### Labels
+
+We have a standard set of labels that should be applied to all repositories. This
+ensures we have a consistent approach to planning and tracking of work.
+
+ - Type: `epic`, `story`, `task`, `bug`
+ - Sizing: `1`, `2`, `3`, `5`, `8`, `13`
+ - Area: `docs`, `db`, `migration`, `frontend`, `api`, `device`
+ - Priority: `p-1`, `p-2`, `p-3`
+ - Status: `blocked`
+ - Product Scope: `scope:devices`, `scope:enterprise`, `scope:node-red`, `scope:collaboration`
+ - Other: `good first issue`, `upstream`
+ 
 ## NPM packages
 
 ### Naming


### PR DESCRIPTION
This documents the standard set of labels we apply to our repositories.

This PR introduces some changes to our existing labels.

 - Adds priority labels (p-1, p-2, p-3)
 - Renames the product scope labels to have the `scope:` prefix
 - Adds some other functional areas that should be highlighted

To create this list, I've looked at what labels we have across all repositories (if you're interested... https://docs.google.com/spreadsheets/d/1iVZxoBRkDt8tZ0izKvgaq8JefKB6qQTGnT2gLDZFigE/edit?usp=sharing)

Some repos have the GitHub-defined set of default labels - many of which we don't use. We have some duplication (`docs` and `documentation` for eg). 

Once this PR is approved in principle, the follow-on actions are:

 - [ ] Update the org-default labels via GitHub settings
 - [ ] Remove the duplicate labels across the repos manually - don't trust a script to do this safely
 - [ ] Use https://github.com/Financial-Times/github-label-sync to create an action in the `.github` repo that can be used to update the labels across all repos as needed.
 - [ ] Add another update to the handbook to document the process for adding an org-wide label.
