### PR TITLE
peopleops: process to create a consistent overview

### DIFF
--- a/peopleops/hiring.md
+++ b/peopleops/hiring.md
@@ -19,6 +19,15 @@ conditional on background checks. If the offer includes an equity component,
 this part is conditional on board approval of such a grant. Be sure to be
 explicit about these conditions.
 
+### After an offer is accepted
+
+Onboarding on our EOR provider, Pilot, takes at least 3 to 4 weeks. The start
+date for a new employee should be at least 3 to 4 weeks out. When a
+[conditional offer](#extending-an-offer) has been accepted you should immediately:
+
+1. [Create an onboarding issue](https://github.com/flowforge/admin/issues/new/choose) on the admin GitHub project
+1. Update the [internal team overview spreadsheet](./index.md#internal-team-overview)
+
 ## Onboarding
 
 Just before the first day working at FlowForge you'll receive an email 

--- a/peopleops/index.md
+++ b/peopleops/index.md
@@ -1,6 +1,11 @@
 - [Compensation](../peopleops/compensation.md)
 - [Hiring](./hiring.md)
 
+## Internal Team Overview
+
+An overview of the current team, soon to be team members, and planned roles can
+be found in [this spreadsheet](https://docs.google.com/spreadsheets/d/1T_J32HFxnvqVZ6Tekf720knk34pKuNdNPI0A3qM43A8).
+
 ## Vacation Policy
 
 FlowForge has a unlimited time off policy. Taking vacation is encouraged for all


### PR DESCRIPTION
While we've got Pilot and BambooHR, there's no consistent overview with open roles, the current team, and what roles are filled. To fix that I've started a spreadsheet. This sheet can only stay consistent if we update it. So I've added it to the handbook to be updated.