### PR TITLE
Add reference to New Repo Checklist issue

### DIFF
--- a/development/packaging.md
+++ b/development/packaging.md
@@ -1,4 +1,11 @@
-FlowForge Packaging Guidelines
+# FlowForge Packaging Guidelines
+
+This section describes the requirements we have for all GitHub repositories,
+and npm modules we maintain.
+
+To help ensure all of the requirements are met, an issue should be raised in
+[`flowforge/admin`](https://github.com/flowforge/admin/issues/new/choose) using
+the `New Repository Checklist` and then worked through.
 
 ## Github projects
 


### PR DESCRIPTION
Assuming https://github.com/flowforge/admin/pull/113 is merged, this adds reference to the New Repo Checklist to our packaging requirements docs.