### PR TITLE
fix channels for howtos

### DIFF
--- a/design/index.md
+++ b/design/index.md
@@ -120,7 +120,7 @@ Each content type has channels which are appropriate, this table sets out which 
 |Outage           |      |             |         |         |         |       |              |                  |
 |Corporate Comms  |*     |             |*        |         |*        |       |              |                  |
 |Newsletter       |*     |*            |*        |         |*        |*      |*             |*                 |
-|How To           |      |*            |*        |         |*        |*      |*             |*                 |
+|How To           |*     |             |*        |         |*        |*      |*             |*                 |
 
 ### Channel Content Guidance
 


### PR DESCRIPTION
We'd said that 'how tos' should be sent to the mailing list but not the blog, that's the wrong way around.