### PR TITLE
Add check for git cli access in release prereqs

### DIFF
--- a/development/release.md
+++ b/development/release.md
@@ -11,6 +11,7 @@ releases.
  - Create a Release checklist issue using the [Release Checklist template](https://github.com/flowforge/admin/issues/new?assignees=&labels=&template=release.md&title=Release%3A)
  - Assign the issue to the Release Manager
  - Ensure you have the following installed on your machine:
+    - git command-line tools.
     - [GitHub client](https://github.com/cli/cli)
     - [jq](https://stedolan.github.io/jq/download/)
     - [yq](https://mikefarah.gitbook.io/yq/#install)

--- a/development/release.md
+++ b/development/release.md
@@ -15,6 +15,7 @@ releases.
     - [jq](https://stedolan.github.io/jq/download/)
     - [yq](https://mikefarah.gitbook.io/yq/#install)
  - Ensure you're machine is authenticated with the GitHub client: `gh auth login`
+ - Ensure you are able to access the FlowForge repositories using the git cli without being prompted for a password: `ssh -T git@github.com`
  - When we are ready to start the release process the Release Manager should start a Slack Huddle in #dev and keep that open until the release is completed.
 
 ### Unmanaged Repositories


### PR DESCRIPTION
## Description

Adds a check that the release manager has password-less access to github from the git cli

