### PR TITLE
Add Handbook meta data for Website Rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+navTitle: Handbook
+---
+
 ## Introduction
 
 This handbook contains all the information about how FlowForge Inc. is run.

--- a/company/index.md
+++ b/company/index.md
@@ -1,3 +1,8 @@
+---
+navTitle: Company
+navGroup: Company
+---
+
 # Company
 
 FlowForge is an open core company creating a low-code programming platform based

--- a/design/index.md
+++ b/design/index.md
@@ -1,3 +1,8 @@
+---
+navTitle: Design
+navGroup: Development & Design Practices
+---
+
 ## Process
 
 ### Scheduling

--- a/development/index.md
+++ b/development/index.md
@@ -1,3 +1,7 @@
+---
+navTitle: Development
+navGroup: Development & Design Practices
+---
 ## Development
 
 ### How we work

--- a/marketing/index.md
+++ b/marketing/index.md
@@ -1,3 +1,8 @@
+---
+navTitle: Marketing & Communication
+navGroup: Sales & Marketing
+---
+
 ## Marketing & Communication 
 
 ### Websites

--- a/media/index.md
+++ b/media/index.md
@@ -1,3 +1,8 @@
+---
+navTitle: Media
+navGroup: Sales & Marketing
+---
+
 ## FlowForge Videos
 
 This section of our handbook is dedicated to guidance on how to create video/media assets for FlowForge. Here you can find information on what types of videos we produce at FlowForge and the templating and formatting we recommend for each. 

--- a/operations/index.md
+++ b/operations/index.md
@@ -1,3 +1,7 @@
+---
+navTitle: Operations
+navGroup: Company
+---
 # Operations
 
 This covers how we run our business and deliver service to our customers.

--- a/peopleops/index.md
+++ b/peopleops/index.md
@@ -1,3 +1,8 @@
+---
+navTitle: Peple Ops
+navGroup: Internal Operations
+---
+
 - [Compensation](../peopleops/compensation.md)
 - [Hiring](./hiring.md)
 

--- a/peopleops/index.md
+++ b/peopleops/index.md
@@ -1,5 +1,5 @@
 ---
-navTitle: Peple Ops
+navTitle: People Ops
 navGroup: Internal Operations
 ---
 

--- a/product/index.md
+++ b/product/index.md
@@ -1,3 +1,7 @@
+---
+navTitle: Product
+navGroup: Company
+---
 # Product
 
 This covers how we run our business and deliver service to our customers.


### PR DESCRIPTION
## Description

With the newly introduced side-navigation for our handbook, we have the option to make "pretty" navigation titles. Have added these into some of the `md` files to make the side navigation easier to parse and read.

The `navGroup` parameter that has been added is in preparation of a second stage, where the top-level navigation will mimic the grouping currently seen in `/handbook/index.md`. Functionality to produce those groups has been added in the attached Website PR, but is not currently used when rendering into the HTML templates (a future piece of work will do this)

## Related Issue(s)

Issue: https://github.com/flowforge/website/issues/193
Paired with development changes in [Website PR](https://github.com/flowforge/website/pull/304)
