### PR TITLE
Split out Design section to make it easier to navigate

### DIFF
--- a/design/branding.md
+++ b/design/branding.md
@@ -1,5 +1,6 @@
 # FlowForge Branding Guidelines
 
+For FlowForge Assets (e.g. logos, pictograms, and raw design files), please look in the [`/design/Media`](https://drive.google.com/drive/u/1/folders/1guBnBUrIiRXuK6vsik_NIXIhtE1cZRRa) folder on Google Drive.
 ## Fonts
 
 In both the FlowForge application and on our website, we use [Tailwind CSS](https://tailwindcss.com/). With Tailwind, comes the `font-sans` class, which we use across FlowForge.

--- a/design/design-thinking.md
+++ b/design/design-thinking.md
@@ -1,5 +1,14 @@
 ## Design Thinking
 
+At FlowForge, we practice Design Thinking when considering our UI design and wider decisions influencing the overall user experience of FlowForge.
+
+> Design Thinking is a non-linear, iterative process that teams use to understand users, challenge assumptions, redefine problems and create innovative solutions to prototype and test.
+>
+> -- <cite>[_Design Thinking, Interaction Design Foundation_](https://www.interaction-design.org/literature/topics/design-thinking)</cite>
+
+As designers and developers, empathising with our users will lead to a better product. When proposing new feature ideas, concepts and changes to existing UX, arguments should always be considered from the perspective of our users. 
+
+Whilst most of the output from our Design Thinking workshops and sessions can be found within [FigJam](#figjam-(more-info)), we have also written up some of our Design Thinking Findings below:
 ### User Personas
 
 Personas are fictional characters that represent the different users we expect to interact with FlowForge as a brand and/or platform. You can find samples of the user personas we have at FlowForge in our [Design Thinking Output](./design-thinking).

--- a/design/index.md
+++ b/design/index.md
@@ -3,67 +3,11 @@ navTitle: Design
 navGroup: Development & Design Practices
 ---
 
-## Process
+## Design
 
-### Scheduling
+This section of our handbook contains all details related to how we design content at FlowForge. From our Branding Guidelines, with logos and color palettes, through to how we plan design work and ensure empathy for users through Design Thinking.
 
-As per our [Development Cadence](../development#cadence), we release a new version of FlowForge every four weeks. Work begins on formal design (mid and high-fidelity UX and visual design assets) two weeks prior to a release cycle beginning, i.e. 6 weeks ahead of the release. 
-
-In getting a headstart on major design work, we ensure that prior thinking has been conducted on the high-level UX, and development is not blocked at the start of a release sprint. Both visual and UX design iterations will occur throughout the first two weeks of a cycle, alongside development efforts.
-
-### Design Thinking
-
-At FlowForge, we practice Design Thinking when considering our UI design and wider decisions influencing the overall user experience of FlowForge.
-
-> Design Thinking is a non-linear, iterative process that teams use to understand users, challenge assumptions, redefine problems and create innovative solutions to prototype and test.
->
-> -- <cite>[_Design Thinking, Interaction Design Foundation_](https://www.interaction-design.org/literature/topics/design-thinking)</cite>
-
-As designers and developers, empathising with our users will lead to a better product. When proposing new feature ideas, concepts and changes to existing UX, arguments should always be considered from the perspective of our users. 
-
-Whilst most of the output from our Design Thinking workshops and sessions can be found within [FigJam](#figjam-(more-info)), we have also written up some of our [Design Thinking Findings here](./design-thinking).
-
-## Branding Guidelines
-
-For FlowForge Assets (e.g. logos, pictograms, and raw design files), please look in the [`/design/Media`](https://drive.google.com/drive/u/1/folders/1guBnBUrIiRXuK6vsik_NIXIhtE1cZRRa) folder on Google Drive.
-
-A breakdown of our branding guidelines details on our Branding guidelines can  be found [here](./branding.md)
-
-## Tools
-
-If you ever require a license to one of the following tools (where applicable), then please read our [licensing](../peopleops#software-licenses) section in order to attain one.
-
-### Figma ([more info](https://www.figma.com/))
-
-Figma is used to construct mid- and high-fidelity designs. We have two primary working documents for design iterations:
-
-- Website
-- Platform
-
-Underlying each of these Figma files is a standardised component library, which coincides with FlowForge's `forge-ui-component` library.
-
-### FigJam ([more info](https://www.figma.com/figjam/))
-
-Figjam, a sister-product of Figma, is a cloud-hosted white boarding tool that enables remote, digital collaboration. 
-
-Any in-person whiteboard discussions should have a documented digitial copy. Additionally, FigJam can be used to host and run digital workshops.
-
-
-### Adobe Creative Cloud ([more info](https://www.adobe.com/uk/creativecloud.html))
-
-For visual design elements of the user interface and public-facing material, we predominantly use Adobe Illustrator and Adobe After Effects.
-
-- **Illustrator** provides us tooling to create high-quality, static SVG assets to suplement the user experience on both the website and the FlowForge platform.
-
-- **After Effects** enables the generation of animated SVG elements. In particular, we work with [Lottie Files](https://lottiefiles.com/) for injection into both our website and FlowForge platform.
-
-Other tools included in the Creative Cloud suite that may be useful include:
-
-- **Photoshop** can be used for raster image and photo-editing.
-
-- **Premiere Pro** is an excellent video-editing software.
-
-### Blender ([more info](https://blender.org))
-
-Blender is a free and open-source 3D computer graphics software toolset. It can be used to create static renders of 3d assets, or entire 2d & 3d animations. 
-
+- [Branding](./branding.md)
+- [Design Thinking](./design-thinking.md)
+- [Process](./process.md)
+- [Tools](./tools.md)

--- a/design/process.md
+++ b/design/process.md
@@ -1,0 +1,7 @@
+## Process
+
+### Scheduling
+
+As per our [Development Cadence](../development#cadence), we release a new version of FlowForge every four weeks. Work begins on formal design (mid and high-fidelity UX and visual design assets) two weeks prior to a release cycle beginning, i.e. 6 weeks ahead of the release. 
+
+In getting a headstart on major design work, we ensure that prior thinking has been conducted on the high-level UX, and development is not blocked at the start of a release sprint. Both visual and UX design iterations will occur throughout the first two weeks of a cycle, alongside development efforts.

--- a/design/tools.md
+++ b/design/tools.md
@@ -1,0 +1,38 @@
+## Tools
+
+If you ever require a license to one of the following tools (where applicable), then please read our [licensing](../peopleops#software-licenses) section in order to attain one.
+
+### Figma ([more info](https://www.figma.com/))
+
+Figma is used to construct mid- and high-fidelity designs. We have two primary working documents for design iterations:
+
+- Website
+- Platform
+
+Underlying each of these Figma files is a standardised component library, which coincides with FlowForge's `forge-ui-component` library.
+
+### FigJam ([more info](https://www.figma.com/figjam/))
+
+Figjam, a sister-product of Figma, is a cloud-hosted white boarding tool that enables remote, digital collaboration. 
+
+Any in-person whiteboard discussions should have a documented digitial copy. Additionally, FigJam can be used to host and run digital workshops.
+
+
+### Adobe Creative Cloud ([more info](https://www.adobe.com/uk/creativecloud.html))
+
+For visual design elements of the user interface and public-facing material, we predominantly use Adobe Illustrator and Adobe After Effects.
+
+- **Illustrator** provides us tooling to create high-quality, static SVG assets to suplement the user experience on both the website and the FlowForge platform.
+
+- **After Effects** enables the generation of animated SVG elements. In particular, we work with [Lottie Files](https://lottiefiles.com/) for injection into both our website and FlowForge platform.
+
+Other tools included in the Creative Cloud suite that may be useful include:
+
+- **Photoshop** can be used for raster image and photo-editing.
+
+- **Premiere Pro** is an excellent video-editing software.
+
+### Blender ([more info](https://blender.org))
+
+Blender is a free and open-source 3D computer graphics software toolset. It can be used to create static renders of 3d assets, or entire 2d & 3d animations. 
+


### PR DESCRIPTION
## Description

Split out the sections of the Design Handbook section so that relevant categories appear in the side navigation for easier finding.

https://user-images.githubusercontent.com/99246719/211110602-55761b72-e474-4b3d-9dbe-54e3651a3943.mov

## Related Issue(s)

https://github.com/flowforge/handbook/issues/180 - Part of the Handbook cleaning

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)