### PR TITLE
Split Company to make it easier to navigate

### DIFF
--- a/company/index.md
+++ b/company/index.md
@@ -6,119 +6,13 @@ navGroup: Company
 # Company
 
 FlowForge is an open core company creating a low-code programming platform based
-on the [OpenJS Foundation Node-RED project](https://nodered.org).
+on the [OpenJS Foundation Node-RED project](https://nodered.org). Here you can find
+information on how we run FlowForge.
 
- - [Strategy](../company/strategy.md)
- - [Board meetings](../company/board.md)
- - [Communication](../company/communication.md)
- - [Security](../company/security.md)
- - [Remote work](../company/remote.md)
-
-# Values
-
-## Be Effective
-
-> [effective][effective-oxford] - producing the result that is wanted or intended; producing a successful result
-
-[effective-oxford]: https://www.oxfordlearnersdictionaries.com/definition/english/effective
-
-Being effective is split up in two parts; producing ***results*** and ***communication***
-about what our goals are.
-
-### Results
-
-#### Results not Hours
-
-We care about what you achieve: the code you shipped, the user you made happy,
-and the team member you helped. We value results over measuring hours spent
-working. We do not dictate how someone should schedule their day - we trust
-individuals to do what is right. Everyone should feel empowered to do the work
-needed to achieve our goals.
-
-There may be times when more is needed to meet a goal, deadline or customer
-situation. We take the responsibility to ensure they are the exceptions rather
-than the rule.
-
-We don't try to compete over the hours we work - everyone does what is right for them.
-We focus on what gets done and take pride in seeing each other succeed.
-
-#### Bias for Action
-
-We value getting things done and continually moving forward. It is better to 
-iterate rapidly rather than get stuck over-thinking a problem. We move with an
-urgency and a focus to achieve our best.
-
-When you disagree with a solution to a problem, provide a concrete alternate
-solution to allow momentum to be maintained or even gained.
-
-Ship the minimum viable change possible. Small changes allow fast feedback loops
-which in turn can aid in deciding the next minimal viable iteration. Further,
-iteration naturally splits big problems into small steps, creates positive
-momentum, and allows to capture value quicker.
-
-#### Be Trusting
-
-To move with high velocity, trust needs to be given before one has had the
-opportunity to earn it. People can only grow when they're able to take up
-challenging tasks and project, and are then allowed to go their own route. When
-challenged, ask for feedback and support, not for permission or approval.
-
-### Communication
-
-#### Community-First
-
-As an open core company our community spans our employees, the open source
-contributors and our users. We strive to build a healthy, positive community
-through our values and actions. We celebrate the diversity of others, we listen
-to each other, we support each other.
-
-We are inclusive of all and are mindful of how our words and actions can impact
-others. We welcome discussion and debate, but take care to ensure it is not at
-the expense or exclusion of others. We value empathy, courtesy and respect for
-each other.
-
-##### Transparency
-
-A community can better aid with the success of FlowForge when they're trusted
-with the same information. This openness builds trust with our community and helps
-in collaboration. Further, it allows for knowledge sharing and builds understanding.
-
-#### Use Candor
-
-We use truth as a superpower, even when inconvenient to ourselves. We use it
-with care and consideration of others. We won’t get everything right all of the
-time. The only way we can improve is by being honest with ourselves and each
-other. It can be difficult to achieve and it can feel awkward. When done right, 
-with respect and a shared understanding, it can lead to a better outcome for
-everyone.
-
-We strongly encourage the sharing of thanks and feedback within FlowForge. This
-can be done formally through our `@Feedback` Slackbot. You can read more in
-[Communications](../communication#feedback-%26-thanks)
-
-#### Be Optimistic
-
-We will treat all situations with an optimism that a positive result is
-possible. We don’t let that get in the way of planning for all outcomes and
-making the hard choices when they are needed.
-
-# Principles
-
-## All Remote
-
-We are a fully remote company that puts a strong emphasis on trust and respect
-for its employees, customers, partners and communities. We are able to hire the
-right people from wherever they are in the world. We work openly with one
-another and value clear communication and decision making without being sat in
-the same room.
-
-## Open Source Stewardship
-
-We believe strongly that Open Source lives at the heart of everything we do. 
-Ever since Node-RED was published as  an Open Source project, we have taken
-great care to stay true to that principle.
-
-Node-RED has an open governance model which means everyone has a seat at the
-table. We will continue to champion that model and work with the community to
-ensure anyone who wants to contribute to the project is able to.
-
+ - [Board meetings](./board.md)
+ - [Communication](./communication.md)
+ - [Principles](./principles.md)
+ - [Remote work](./remote.md)
+ - [Security](./security.md)
+ - [Strategy](./strategy.md)
+ - [Values](./values.md)

--- a/company/principles.md
+++ b/company/principles.md
@@ -1,0 +1,21 @@
+
+# Principles
+
+## All Remote
+
+We are a fully remote company that puts a strong emphasis on trust and respect
+for its employees, customers, partners and communities. We are able to hire the
+right people from wherever they are in the world. We work openly with one
+another and value clear communication and decision making without being sat in
+the same room.
+
+## Open Source Stewardship
+
+We believe strongly that Open Source lives at the heart of everything we do. 
+Ever since Node-RED was published as  an Open Source project, we have taken
+great care to stay true to that principle.
+
+Node-RED has an open governance model which means everyone has a seat at the
+table. We will continue to champion that model and work with the community to
+ensure anyone who wants to contribute to the project is able to.
+

--- a/company/values.md
+++ b/company/values.md
@@ -1,0 +1,87 @@
+## Values
+
+### Be Effective
+
+> [effective][effective-oxford] - producing the result that is wanted or intended; producing a successful result
+
+[effective-oxford]: https://www.oxfordlearnersdictionaries.com/definition/english/effective
+
+Being effective is split up in two parts; producing ***results*** and ***communication***
+about what our goals are.
+
+### Results
+
+#### Results not Hours
+
+We care about what you achieve: the code you shipped, the user you made happy,
+and the team member you helped. We value results over measuring hours spent
+working. We do not dictate how someone should schedule their day - we trust
+individuals to do what is right. Everyone should feel empowered to do the work
+needed to achieve our goals.
+
+There may be times when more is needed to meet a goal, deadline or customer
+situation. We take the responsibility to ensure they are the exceptions rather
+than the rule.
+
+We don't try to compete over the hours we work - everyone does what is right for them.
+We focus on what gets done and take pride in seeing each other succeed.
+
+#### Bias for Action
+
+We value getting things done and continually moving forward. It is better to 
+iterate rapidly rather than get stuck over-thinking a problem. We move with an
+urgency and a focus to achieve our best.
+
+When you disagree with a solution to a problem, provide a concrete alternate
+solution to allow momentum to be maintained or even gained.
+
+Ship the minimum viable change possible. Small changes allow fast feedback loops
+which in turn can aid in deciding the next minimal viable iteration. Further,
+iteration naturally splits big problems into small steps, creates positive
+momentum, and allows to capture value quicker.
+
+#### Be Trusting
+
+To move with high velocity, trust needs to be given before one has had the
+opportunity to earn it. People can only grow when they're able to take up
+challenging tasks and project, and are then allowed to go their own route. When
+challenged, ask for feedback and support, not for permission or approval.
+
+### Communication
+
+#### Community-First
+
+As an open core company our community spans our employees, the open source
+contributors and our users. We strive to build a healthy, positive community
+through our values and actions. We celebrate the diversity of others, we listen
+to each other, we support each other.
+
+We are inclusive of all and are mindful of how our words and actions can impact
+others. We welcome discussion and debate, but take care to ensure it is not at
+the expense or exclusion of others. We value empathy, courtesy and respect for
+each other.
+
+##### Transparency
+
+A community can better aid with the success of FlowForge when they're trusted
+with the same information. This openness builds trust with our community and helps
+in collaboration. Further, it allows for knowledge sharing and builds understanding.
+
+#### Use Candor
+
+We use truth as a superpower, even when inconvenient to ourselves. We use it
+with care and consideration of others. We won’t get everything right all of the
+time. The only way we can improve is by being honest with ourselves and each
+other. It can be difficult to achieve and it can feel awkward. When done right, 
+with respect and a shared understanding, it can lead to a better outcome for
+everyone.
+
+We strongly encourage the sharing of thanks and feedback within FlowForge. This
+can be done formally through our `@Feedback` Slackbot. You can read more in
+[Communications](../communication#feedback-%26-thanks)
+
+#### Be Optimistic
+
+We will treat all situations with an optimism that a positive result is
+possible. We don’t let that get in the way of planning for all outcomes and
+making the hard choices when they are needed.


### PR DESCRIPTION
## Description

Split out the sections of the Company Handbook section so that relevant categories appear in the side navigation for easier finding.

## Related Issue(s)

https://github.com/flowforge/handbook/issues/180 - Part of the Handbook cleaning

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)