### PR TITLE
Split Product to make it easier to navigate

### DIFF
--- a/product/customer-calls.md
+++ b/product/customer-calls.md
@@ -1,0 +1,14 @@
+---
+navTitle: Customer Calls
+---
+
+### Customer calls
+
+FlowForge is fortunate to have a community the size of Node-REDs community. The
+product organisation should constantly be in touch with the community to
+understand their challenges, current solutions, and learn why they have or
+haven't adopted FlowForge.
+
+For each call document all the learnings to share internally, to start; make a
+copy of [this template](https://docs.google.com/document/d/1_gya2WZTJW0G2CxlsJguLDCJI3eHRILJzd9ICsn5QTs)
+and roughly follow the questions listed.

--- a/product/demos.md
+++ b/product/demos.md
@@ -1,0 +1,22 @@
+---
+navTitle: Product Demos
+---
+
+### Product Demos
+
+Product demos are held internally to rapidly assess the state of a feature set
+and allow for synchronous validation of feature sets. Each demo is open to the
+whole company to allow for cross functional learning and development.
+
+A demo consists of a higher level business goal to achieve and is graded against
+that goal. Once that goal is set, the goal needs to broken down into smaller
+steps to create a script. For each meeting a participant should be marked as
+demo leader, going through the steps and try and achieve a successful demo.
+
+The demo itself is a recorded meeting where the demo leader goes through the
+script. It's anticipated that demos surface friction or fail completely. When
+problems, challenges, and/or improvement-ideas arise another participant should
+document these along with the script. When the demo is completed, these tasks
+are discussed and prioritized.
+
+Afterwards the next demo is scheduled, and the next demo-leader is chosen.

--- a/product/index.md
+++ b/product/index.md
@@ -6,37 +6,9 @@ navGroup: Company
 
 This covers how we run our business and deliver service to our customers.
 
-- [Plan](../product/plan.md)
-- [Versioning](../product/versioning.md)
-- [Pricing Principles](../product/pricing.md)
-- [Market Verticals](../product/verticals.md)
-
-### Product Demos
-
-Product demos are held internally to rapidly assess the state of a feature set
-and allow for synchronous validation of feature sets. Each demo is open to the
-whole company to allow for cross functional learning and development.
-
-A demo consists of a higher level business goal to achieve and is graded against
-that goal. Once that goal is set, the goal needs to broken down into smaller
-steps to create a script. For each meeting a participant should be marked as
-demo leader, going through the steps and try and achieve a successful demo.
-
-The demo itself is a recorded meeting where the demo leader goes through the
-script. It's anticipated that demos surface friction or fail completely. When
-problems, challenges, and/or improvement-ideas arise another participant should
-document these along with the script. When the demo is completed, these tasks
-are discussed and prioritized.
-
-Afterwards the next demo is scheduled, and the next demo-leader is chosen.
-
-### Customer calls
-
-FlowForge is fortunate to have a community the size of Node-REDs community. The
-product organisation should constantly be in touch with the community to
-understand their challenges, current solutions, and learn why they have or
-haven't adopted FlowForge.
-
-For each call document all the learnings to share internally, to start; make a
-copy of [this template](https://docs.google.com/document/d/1_gya2WZTJW0G2CxlsJguLDCJI3eHRILJzd9ICsn5QTs)
-and roughly follow the questions listed.
+- [Customer Calls](./customer-calls.md)
+- [Market Verticals](./verticals.md)
+- [Plan](./plan.md)
+- [Pricing Principles](./pricing.md)
+- [Product Demos](./demos.md)
+- [Versioning](./versioning.md)

--- a/product/pricing.md
+++ b/product/pricing.md
@@ -1,3 +1,7 @@
+---
+navTitle: Pricing Principles
+---
+
 # Pricing Principles
 
 This page sets out the concepts that we sell and how those are measured across both SaaS and Licensed Editions of the platform.

--- a/product/verticals.md
+++ b/product/verticals.md
@@ -1,3 +1,7 @@
+---
+navTitle: Market Verticals
+---
+
 # Product Verticals
 
 ## Background


### PR DESCRIPTION
## Description

Split out the sections of the Product Handbook section so that relevant categories appear in the side navigation for easier finding.

## Related Issue(s)

https://github.com/flowforge/handbook/issues/180 - Part of the Handbook cleaning

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
