### PR TITLE
Add npm test files for checking valid links

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "flowforge-handbook",
+    "version": "1.0.0",
+    "description": "Repository to manage and test all of the content for FlowForge's Company Handbook.",
+    "private": true,
+    "devDependencies": {
+        "axios": "^1.2.2",
+        "html-link-extractor": "^1.0.5",
+        "marked": "^4.2.5",
+        "npm-run-all": "^4.1.5"
+    },
+    "scripts": {
+        "test": "node tests/valid-links.js ../../"
+    },
+    "keywords": [],
+    "author": "Joe Pavitt",
+    "license": "Apache-2.0"
+}

--- a/.github/scripts/tests/valid-links.js
+++ b/.github/scripts/tests/valid-links.js
@@ -1,0 +1,202 @@
+const { readFileSync, readdirSync, access, F_OK, statSync} = require('fs');
+const { marked } = require('marked');
+const htmlLinkExtractor = require('html-link-extractor');
+const url = require("url");
+const axios = require('axios');
+const path = require('path');
+
+marked.setOptions({
+    mangle: false, // don't escape autolinked email address with HTML character references.
+});
+
+const GREEN = '\x1b[32m'
+const YELLOW = '\x1b[33m'
+const RED = '\x1b[31m'
+const RESET = '\x1b[0m'
+
+const ignoreFolders = [
+    '.github'
+]
+
+// URLs we expect to be invalid, and that's okay
+const exceptions = [
+    'forge.example.com',
+    'github.com/flowforge/admin',
+    'github.com/flowforge/docker-compose',
+    'github.com/flowforge/nodered.snap',
+    'github.com/flowforge/flowforge-data',
+    'github.com/flowforge/ctrlx-node-red-example',
+    'github.com/flowforge/CloudProject',
+    'github.com/flowforge/content',
+    'github.com/flowforge/security',
+    'github.com/orgs/flowforge/projects'
+]
+
+const isUrlException = function (link) {
+    for (let i = 0; i < exceptions.length; i++) {
+        if (link.includes(exceptions[i])) {
+            return true
+        }
+    }
+    return false
+}
+
+const getAllMdFiles = function(dirPath, arrayOfFiles) {
+    files = readdirSync(dirPath)
+  
+    var arrayOfFiles = arrayOfFiles || []
+  
+    files.forEach(function(file) {
+        if (!ignoreFolders.includes(file)) {
+            if (statSync(dirPath + "/" + file).isDirectory()) {
+                arrayOfFiles = getAllMdFiles(dirPath + "/" + file, arrayOfFiles)
+              } else {
+                if (file.endsWith('.md')) {
+                    arrayOfFiles.push(path.join(dirPath, "/", file))
+                }
+              }
+        }
+      
+    })
+  
+    return arrayOfFiles
+}
+
+var linkCount = 0
+
+// track details of any errors found for nicer reporting at the end
+var errorRecords = {
+    'internal': [],
+    'external': []
+}
+
+/*
+ * Given a file path, read it, and check the validity of any links
+*/
+async function testLinks (fileUri) {
+    // ensure it's a markdown file
+    if (!fileUri.endsWith('.md')) {
+        throw Error(`${fileUri} is not an .md file`)
+    }
+
+    const markdown = readFileSync(fileUri, {encoding: 'utf8'});
+    const html = marked(markdown);
+    var links = htmlLinkExtractor(html);
+
+    let errors = 0
+    let promises = []
+
+    // remove localhost links - they're generally just instructional, not live links
+    // remove # anchor links, not sure how to test these at the moment
+    // remove email links
+    // remove exceptions - links we now are broken
+    links = links.filter((link) => {
+        const linkData = url.parse(link)
+        return linkData.hostname !== 'localhost' && !link.includes('#') && !link.includes('mailto') && !isUrlException(link)
+    })
+
+    linkCount += links.length
+
+    console.log(`\n\n\x1b[33m Running Link Tests: ${fileUri}`)
+
+    links.forEach(async (link) => {
+        const linkData = url.parse(link)
+        if (!linkData.protocol) {
+            // internal links - validate via file system
+            promises.push(new Promise((resolve, reject) => {
+                const localDir = fileUri.substr(0, fileUri.lastIndexOf('/'))
+                var uri = ''
+                if (link.startsWith('/')) {
+                    // absolute path from /src
+                    uri = path.join(__dirname, '../src/', link)
+                } else {
+                    // link defined as relative to fileUri
+                    uri = path.join(__dirname, '../', localDir, link)
+                }
+                access(uri, F_OK, (err) => {
+                    if (err) {
+                        console.error(`${RED} X Invalid Link: ${link}`)
+                        errorRecords['internal'].push({
+                            source: fileUri,
+                            target: link,
+                            uri: uri,
+                            reason: 404
+                        })
+                        errors += 1
+                    } else {
+                        console.log(`${GREEN} /   Valid Link: ${link}`)
+                    }
+                    resolve()
+                })
+            }))
+        } else {
+            // external link - let's validate using HTTP request
+            promises.push(axios.get(link)
+                .then(() => {
+                    console.log(`${GREEN} /   Valid Link: ${link}`)
+                })
+                .catch(err => {
+                    if (err.response) {
+                        const status = err.response.status
+                        if ([404, 410].includes(status)) {
+                            console.error(`${RED} X Invalid Link: ${err.response.status} ${link}`)
+                            errorRecords['external'].push({
+                                source: fileUri,
+                                target: link,
+                                reason: err.response.status
+                            })
+                            errors += 1
+                        }
+                    } else {
+                        // not an error triggered by the HTTP response
+                        console.error(`Error Retrieving: ${link}`)
+                        throw Error(err)
+                    }
+                })
+            )
+        }
+    })
+
+    return Promise.all(promises).then(() => {
+        console.log(`\n${YELLOW}------ REPORT ------`)
+        console.log(`${YELLOW} TESTED:` + `${links.length}`.padStart(12))
+        console.log(`${GREEN}  VALID:` + `${links.length - errors}`.padStart(12))
+        console.log(`${RED} ERRORS:` + `${errors}`.padStart(12))
+    });
+}
+
+async function parseDirectory(dir) {
+    let handbook = getAllMdFiles(dir)
+    
+    for (let i = 0; i < handbook.length; i++) {
+        const file = handbook[i]
+        await testLinks(file)
+    }
+}
+
+async function runReport (dir) {
+    await parseDirectory(dir)
+    const errorCount = errorRecords.internal.length + errorRecords.external.length
+    console.log(`\n\n${RED}------ INTERNAL ERRORS ------${RESET}`)
+    console.log(errorRecords.internal)
+    console.log(`\n${RED}------ EXTERNAL ERRORS ------${RESET}`)
+    console.log(errorRecords.external)
+    console.log(`\n${YELLOW}------ FINAL REPORT ------`)
+    console.log(`${YELLOW} TESTED:` + `${linkCount}`.padStart(20))
+    console.log(`${GREEN}  VALID:` + `${linkCount - errorCount}`.padStart(20))
+    console.log(`${RED} ERRORS:` + `${errorCount}`.padStart(20))
+
+    if (errorCount > 1) {
+        // ensure process fails for reporting in GH Action
+        process.exitCode = 1
+    }
+}
+
+// take file directory as argument
+if (!process.argv[2]) {
+    throw Error('please pass a directory to search through and test, e.g. node valid-links.js /my-dir/')
+} else {
+    runReport(process.argv[2])
+}
+
+return;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test Handbook Links
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+jobs:
+  test:
+    if: ${{ github.repository == 'flowforge/handbook' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      # Install NPM dependencies
+      - name: Install Dependencies
+        run: npm install
+      # Run Tests
+      - run: npm test
+        working-directory: 'handbook'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
     if: ${{ github.repository == 'flowforge/handbook' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: '14'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
       # Install NPM dependencies
       - name: Install Dependencies
         run: npm install
+        working-directory: '.github/scripts'
       # Run Tests
       - run: npm test
-        working-directory: 'handbook'
+        working-directory: '.github/scripts'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.github/scripts/node_modules
+.github/scripts/package-lock.json


### PR DESCRIPTION
## Description

Add npm testing content into .github folder to retain handbook hierarchy.

## Related Issue(s)

[<!-- What issue does this PR relate to? -->](https://github.com/flowforge/website/issues/315)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

