### PR TITLE
navigation: Fix link to values

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and strongly encouraged.
 
 ### Company
 
- - [Values](./company)
+ - [Values](./company/values.md)
  - [Strategy](./company/strategy.md)
  - [Operations](./operations)
  - [Product](./product)


### PR DESCRIPTION
If I click a link to values, its surprising to be redirected to a page that's not the values page. This change fixes that.
