### PR TITLE
Improve page titles for sharing

### DIFF
--- a/company/board.md
+++ b/company/board.md
@@ -1,3 +1,6 @@
+---
+navTitle: Board
+---
 # Board of Directors
 
 ## Board meetings

--- a/company/communication.md
+++ b/company/communication.md
@@ -1,3 +1,7 @@
+---
+navTitle: Communications
+---
+
 As a distributed company we should be mindful of how we communicate.
 
 ## Date and time

--- a/company/principles.md
+++ b/company/principles.md
@@ -1,3 +1,7 @@
+---
+meta:
+    title: Company Principles
+---
 
 # Principles
 

--- a/company/security.md
+++ b/company/security.md
@@ -1,3 +1,7 @@
+---
+navTitle: Security
+---
+
 # Security
 
 ## Credentials

--- a/company/strategy.md
+++ b/company/strategy.md
@@ -1,3 +1,8 @@
+---
+meta:
+    title: Company Strategy
+---
+
 ### Strategy
 
 > We will only be successful if the whole Node-RED community is successful.

--- a/company/values.md
+++ b/company/values.md
@@ -1,3 +1,7 @@
+---
+meta:
+    title: Company Values
+---
 ## Values
 
 ### Be Effective

--- a/design/design-thinking.md
+++ b/design/design-thinking.md
@@ -9,6 +9,10 @@ At FlowForge, we practice Design Thinking when considering our UI design and wid
 As designers and developers, empathising with our users will lead to a better product. When proposing new feature ideas, concepts and changes to existing UX, arguments should always be considered from the perspective of our users. 
 
 Whilst most of the output from our Design Thinking workshops and sessions can be found within [FigJam](#figjam-(more-info)), we have also written up some of our Design Thinking Findings below:
+
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FJxQe6yIm6lSIYvVi1FYCtl%2FUser-Journey---Onboarding%3Fnode-id%3D0%253A1%26t%3DsqwjX18jUzm00GWk-1" allowfullscreen></iframe>
+
+
 ### User Personas
 
 Personas are fictional characters that represent the different users we expect to interact with FlowForge as a brand and/or platform. You can find samples of the user personas below.

--- a/development/frontend/data-attributes.md
+++ b/development/frontend/data-attributes.md
@@ -1,3 +1,7 @@
+---
+navTitle: Data Attributes
+---
+
 ## Data Attributes
 
 It is recommended in the [Cypress Best Practices](https://docs.cypress.io/guides/references/best-practices#Selecting-Elements) to utilise `data-` attributes on HTML elements in order to ensure safe selection of objects that won't evolve/change over time.

--- a/development/frontend/index.md
+++ b/development/frontend/index.md
@@ -1,3 +1,7 @@
+---
+navTitle: Front End
+---
+
 ### Front-End
 
 A collection of how-to's and best practice guides for FlowForge's front-end development.

--- a/development/frontend/services.md
+++ b/development/frontend/services.md
@@ -1,3 +1,8 @@
+---
+meta:
+  title: Front-End Services
+---
+
 ## Services
 The frontend contains two helper services that can be called anywhere in the UI. Each of the services control components built into the main `Platform.vue`.
 

--- a/development/frontend/testing.md
+++ b/development/frontend/testing.md
@@ -1,3 +1,8 @@
+---
+meta:
+    title: Front-End Testing
+---
+
 ## Front-End Testing
 
 For our front-end we test on two fronts:

--- a/development/how-we-work/packaging.md
+++ b/development/how-we-work/packaging.md
@@ -1,3 +1,7 @@
+---
+navTitle: Packaging Guidelines
+---
+
 # Packaging Guidelines
 
 This section describes the requirements we have for all GitHub repositories,

--- a/development/releases/index.md
+++ b/development/releases/index.md
@@ -1,3 +1,7 @@
+---
+navTitle: Releases
+---
+
 ### Releases
 
 Instructions for creating a release are found in the Release Process [here](./process.md).

--- a/development/releases/planning.md
+++ b/development/releases/planning.md
@@ -1,3 +1,7 @@
+---
+navTitle: Planning
+---
+
 ## Planning
 
 Instructions for creating a release are [here](./process.md).

--- a/marketing/blog.md
+++ b/marketing/blog.md
@@ -1,3 +1,8 @@
+---
+meta:
+    title: Marketing - Blog
+---
+
 ## Blog
 
 ### Blogging Process

--- a/marketing/channels.md
+++ b/marketing/channels.md
@@ -1,3 +1,6 @@
+---
+navTitle: Content Channels
+---
 
 ## Content Channels
 

--- a/marketing/types.md
+++ b/marketing/types.md
@@ -1,3 +1,7 @@
+---
+navTitle: Content Types
+---
+
 ## Content Types
 
 Content should be published to the appropriate channels, the types of published content we currently produce are as follows.

--- a/marketing/website.md
+++ b/marketing/website.md
@@ -1,4 +1,8 @@
 
+---
+navTitle: Marketing - Website
+---
+
 ### Website
 
 - All written content should be in UK English.

--- a/operations/accounts.md
+++ b/operations/accounts.md
@@ -1,3 +1,7 @@
+---
+navTitle: Accounts
+---
+
 # Accounts
 
 These are the principles of how we setup and use accounts on the FlowForge.cloud platform.

--- a/operations/billing.md
+++ b/operations/billing.md
@@ -1,3 +1,7 @@
+---
+navTitle: Billing
+---
+
 # Billing
 
 ## Platform

--- a/operations/change.md
+++ b/operations/change.md
@@ -1,3 +1,7 @@
+---
+navTitle: Change Control
+---
+
 # Change Control
 
 To keep track of what changes where made, why these were made, and if the changes

--- a/operations/data.md
+++ b/operations/data.md
@@ -1,3 +1,7 @@
+---
+navTitle: Data at FlowForge
+---
+
 # Data at FlowForge
 
 At FlowForge we're trying to leverage data obtained to make better decisions.

--- a/operations/support.md
+++ b/operations/support.md
@@ -1,3 +1,7 @@
+---
+navTitle: Support
+---
+
 # Support
 
 ## Customer type

--- a/operations/vendors.md
+++ b/operations/vendors.md
@@ -1,3 +1,7 @@
+---
+navTitle: Vendors
+---
+
 # Vendors
 
 ### Process

--- a/peopleops/compensation.md
+++ b/peopleops/compensation.md
@@ -1,3 +1,6 @@
+---
+navTitle: Compensation
+---
 # Compensation
 
 Total compensation consists of 3 elements, salary, equity, and benefits.

--- a/peopleops/expenses.md
+++ b/peopleops/expenses.md
@@ -1,3 +1,7 @@
+---
+navTitle: Expenses
+---
+
 ## Expenses
 
 The company will cover any reasonable work-related expense, including ensuring you

--- a/peopleops/hiring.md
+++ b/peopleops/hiring.md
@@ -1,3 +1,7 @@
+---
+navTitle: Hiring
+---
+
 ## Hiring
 
 ### Interviews

--- a/product/plan.md
+++ b/product/plan.md
@@ -1,3 +1,6 @@
+---
+navTitle: Plan
+---
 # Product Plan
 
 ## Background

--- a/product/versioning.md
+++ b/product/versioning.md
@@ -1,3 +1,7 @@
+---
+navTitle: Versioning
+---
+
 # Versioning
 
 ## 1.0


### PR DESCRIPTION
## Description

Adds `navTitle` or `meta.title` where relevant. The latter is used where we _only_ want it to show in the title of the tab/share, not in the side navigation of the Handbook.

It's on my todo list to write a section in the handbook about the different properties/fields we have available.

## Related Issue(s)

Linked to https://github.com/flowforge/website/pull/374 as that enabled the inclusion of these in the page titles.