### PR TITLE
Fix typo in Dialog import statement

### DIFF
--- a/development/frontend/services.md
+++ b/development/frontend/services.md
@@ -34,7 +34,7 @@ The service is built from the [ff-notification-toast](https://flowforge.github.i
 The Dialog service should be used when user confirmation is required, after an action has been taken. For example, if a user attempts to delete a resource, a confirmation Dialog should be shown to ensure this was not an accidental action.
 
 ```js
-import Dialog from '@services/dialog'
+import Dialog from '@/services/dialog'
 
 /*
  * msg      - {


### PR DESCRIPTION
## Description

Noticed (when using it) that the example for the Dialog service in our front-end development guides has an incorrect import statement

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Documentation has been updated
    - [x] Upgrade instructions