### PR TITLE
Add docs on feature demos

### DIFF
--- a/development/releases/planning.md
+++ b/development/releases/planning.md
@@ -6,17 +6,8 @@ navTitle: Planning
 
 Instructions for creating a release are [here](./process.md).
 
-FlowForge is released every four weeks, on a Thursday. There are 13 releases each
-year. The initial release was published on 2022-01-20. This implies releases
-will be scheduled on the following dates.
-
- -  2022/07/07 (0.7)
- -  2022/08/04 (0.8)
- -  2022/09/01 (0.9)
- -  2022/09/29 (0.10)
- -  2022/10/27 (1.0)
- -  2022/11/24 (1.1)
- -  2022/12/22 (1.2)
+FlowForge is released every four weeks, on a Thursday. We track releases using
+GitHub Milestones. The current schedule of releases can be seen [here](https://github.com/flowforge/flowforge/milestones).
 
 Our planning process is continually evolving as we find the right way to accommodate
 both a growing team and a growing set of requirements on both how and what we deliver.
@@ -46,6 +37,9 @@ to the Product Board for prioritization and planning. The exception to this are
 tasks/bugs related to work already in progress and that need to be addressed in
 the current milestone. They should be added to the Development Board and current
 milestone directly.
+
+We label some items as `headline`. These are items we want to highlight in the release
+announcement material and should clearly describe the value they bring to our users.
 
 ### Project Boards
 
@@ -131,13 +125,10 @@ by the CTO. This meeting includes 2 parts:
 
 ### What to work on
 
-Work comes from two places:
+Work comes the ToDo column of the [Development Board](https://github.com/orgs/flowforge/projects/1/views/1).
 
- - Items assigned for Design/Estimation on the Product Board
- - Items from the ToDo status on the Development Board
-
-It is important we make progress on both sides to ensure a steady velocity across
-milestones.
+We use a set of labels to identify the high/medium/low priority of an item. We tend to
+flag the more important stuff and treat an unlabelled item is implicitly low priority.
 
 Naturally there will be items that crop up unexpectedly and have to be dealt with
 pragmatically. For example, we may realise an item is needed for the current release
@@ -145,7 +136,7 @@ that needs to be expedited through the process. We should remain flexible in how
 we work.
 
 When picking up an unassigned item assign it to yourself and move it to the
-**In Progress** state (for Development items) or the appropriate Product board state.
+**In Progress** state.
 
 #### Milestones are overscheduled
 
@@ -167,3 +158,23 @@ criteria are met:
  - Acceptance criteria identified in the Story have been met
  - Product Owner accepts the story is complete
 
+#### Feature Demos
+
+Part of finishing an item is being able to demonstrate it in action. This allows others
+to see it in action, generate material for the release announcement and help identify
+any gaps or places for improvement.
+
+All `headline` item or significant piece of functionality should be demoed.
+
+Demos must be done in good time within the release cycle to allow for any follow-up
+action. It is better to demo something 90% complete and get feedback on it, than it
+is to rush a demo without time to do anything with it.
+
+Demos should consist of:
+
+ - A short (< 5 minute where possible) screen capture walk through of the feature with commentary.
+ - It should cover the feature from a users perspective - what value do they get from it.
+ - The video should be uploaded to, or linked to, in the relevant issue.
+ - A link should be posted to the `#feature-demos` channel in slack. This will allow the whole team to be notified of the demo without having to subscribe to every issue comment.
+
+For some features, it may be necessary to create multiple demos of different aspects.


### PR DESCRIPTION
This is a redo of #174 which had merge conflicts following handbook reorganisation.

In hindsight, the merge conflicts weren't as hard to resolve as I thought, but this is a clean branch with the changes reapplied. The contents hasn't changed.

Given the approval against 174, I'll self merge this.