### PR TITLE
meeting: Split KPI meeting to their own meeting

### DIFF
--- a/company/communication.md
+++ b/company/communication.md
@@ -91,15 +91,15 @@ Pro-tips:
 Weekly a meeting is held to announce company wide updates, get to know each
 other, and share things you want to share both professionally and personally.
 
-The meeting starts with announcements and reporting on [key metrics](../company/strategy.md#key-metrics)
-These should be written down in the agenda as participation is not required.
-Reading the agenda the day after the meeting should be enough to stay in the
-loop on company updates. Announcements and work related topics are timeboxed to
-the first 15 minutes of the meeting to allow plenty time to talk about other
-topics.
-
 Personal updates don't have to be documented in the agenda, but please do keep a
 list of names in the agenda so everyone gets the opportunity to share.
+
+### Bi-weekly KPI meeting
+
+This 25-minute meeting is held to report on [key metrics](../company/strategy.md#key-metrics).
+Every department gets 5 minutes to explain what initiatives have been implemented
+over the past 2 weeks, what initiatives or milestones are scheduled for the next
+two weeks, and what results are expected to the company wide KPI.
 
 ## Node-RED community interactions.
 


### PR DESCRIPTION
The weekly call is now around KPIs and personal updates, this conflates the meeting and makes it unfocussed. Now the team is growing we'd create a meeting where department leaders will inform and discuss their progress.
