### PR TITLE
hiring: How to greenhouse

### DIFF
--- a/peopleops/hiring.md
+++ b/peopleops/hiring.md
@@ -2,9 +2,9 @@
 navTitle: Hiring
 ---
 
-## Hiring
+# Hiring
 
-### Interviews
+## Interviews
 
 When a candidate applied they'll have at least two interviews with two different
 interviewers before an offer is extended to them. One interview will investigate
@@ -15,7 +15,7 @@ When interviewing to hire new team members, optimize for value-fit over
 culture-fit. Hiring for value-fit allows others to add to culture and thus fosters
 diversity and inclusivity.
 
-#### STAR interviews
+### STAR interviews
 
 Using [the STAR framework](https://www.themuse.com/advice/star-interview-method)
 candidates will be interviewed to describe their experiences in the past.
@@ -25,7 +25,7 @@ future.
 For the interviewer a template is available with the [STAR questions](https://docs.google.com/document/d/1v6C1Tf6B-hDOlA9GhR44Y2ftDgiwx4x_twnuo_N4pZE)
 to make a copy of.
 
-### Extending an offer
+## Extending an offer
 
 When a candidate goes through the full hiring process an offer might be extended
 to them. At such a time it's good to understand that the offer at that time is
@@ -35,7 +35,7 @@ explicit about these conditions.
 
 Please use [this template](https://docs.google.com/document/d/1rY0gLLpkOPBVGlMy7PVhnVjmRF53MhkeDET4TkfPJIs) to stage an email.
 
-### After an offer is accepted
+## After an offer is accepted
 
 Onboarding on our EOR provider, Pilot, takes at least 3 to 4 weeks. The start
 date for a new employee should be at least 3 to 4 weeks out. When a
@@ -60,3 +60,93 @@ to Slack, the FlowForge GitHub organisation, and complete your onboarding issue.
 Your manager will also assign work to start on in the first week.
 
 [issue-tracker]: https://github.com/flowforge/admin/issues
+
+## Greenhouse
+
+### Opening a Job
+
+When opening a job post, you'll need a couple of things:
+1. A draft Job Description
+1. Approved role availability
+1. Support for a PeopleOps Manager to setup the role in Greenhouse
+
+Once these are in place a pipeline needs to be designeed by the PeopleOps manager.
+
+### Pipeline design
+
+A pipeline needs to be designed, meaning; you'll need to define all stages of the hiring process.
+
+#### Accepting applications
+
+Applicants for a job must provide their resume. Optionally a cover letter could
+be supplied. Furthermore, it's recommended to include one or two acceptance
+questions to filter applicants. These questions should be related to the position
+being opened. For example; for a developer you might ask what happens if someone
+types `https://flowforge.com` in their browser, after they press enter. Aim to
+be thought provoking with the question, though the answer shouldn't take over
+a minute or two to think of and type for a skilled candidate.
+
+#### Initial Review
+
+The initial review will check the aforementioned question for validity, the resume, and the cover letter.
+Check for:
+1. Alignment to [Values](../company/values.md)
+1. Capabilities align with the requirements for the role
+1. Previous retention at companies
+   - We'd like people to join the company for the long term, if their previous roles suggest the candidate will not join for the long term please reject them
+
+For each candidate we'd like to move forward with, a scorecard needs to be filled
+out based on the available information so the interviewer for the next stage can
+prepare and focus if the strengths are indeed strong, and the same for weaknesses or uncertainties.
+
+The resume review should reject **over 50%** of all candidates.
+
+#### Screening Call
+
+The initial screening call is intended as an additional filter for FlowForge, but also for the candidate. Screening calls are held on a video call, and the candidate should have plenty of time to ask question and understand if this role is right for them.
+During this call FlowForge should understand:
+1. Alignment to [Values](../company/values.md)
+1. The candidate is enthusiastic about the company and the open role
+1. Compensation range for the candidate
+1. Notice period, or time from offer to start
+
+For all candidates that are moved on the next stage a scorecard needs to be filled out.
+
+After this stage **no more than 25%** of the total number of candidates should remain.
+
+#### Skills assessment
+
+For each role a skills assessment will be performed. This stage will be different for most roles. This is the main stage to asses the capabilities.
+
+This round will again result in a scorecard, but also an indication what level this candidate would suit in.
+For example `intermediate` vs `senior` for developers.
+
+When in doubt, reject the candidate.
+
+#### STAR interview
+After the skills assessment, the last round includes a behaviour interview. STAR interviews are aimed at discussing the candidates past performance in certain situations, and hopefully predict the way they acted is in line with FlowForge expectations.
+
+Again, a scoresheet will be filled out.
+
+#### Offer stage
+
+First, read about [extending offers](#extending-offers).
+
+At the offer stage all scorecards will be re-evaluated to understand what the candidate strengths and challenges are.
+Before the peopleops team extends an offer, explicit approval is required from:
+1. A peopleops manager
+   - Check we hire in their location
+   - Notice period aligns with internal processes
+   - Total compensation is in FlowForge's range
+1. The new manager of the candidate
+1. CEO
+
+When a candidate accepted an offer, proceed to [onboard them](#after-accepting-an-offer).
+
+### Closing a job
+
+As soon as there's a pipeline that would support at least three strong candidates
+for the open position, take the job posting offline. Candidates applying for a job
+that's no longer available is a waste of their time and a bad experience with
+FlowForge and hurts our reputation.
+


### PR DESCRIPTION
These tips were in Slab, but that didnt' end up hosting our handbook. So this change moves the content over so we capture it.